### PR TITLE
Update to version 28.2

### DIFF
--- a/docs/att_interface_definition/CommonEventFormat.json
+++ b/docs/att_interface_definition/CommonEventFormat.json
@@ -1141,31 +1141,31 @@
 			"type": "object",
 			"properties": {
 				"memoryBuffered": { 
-                    "description": "kilobytes of temporary storage for raw disk blocks", 
+                    "description": "kibibytes of temporary storage for raw disk blocks", 
                     "type": "number" 
                 },
 				"memoryCached": { 
-                    "description": "kilobytes of memory used for cache", 
+                    "description": "kibibytes of memory used for cache", 
                     "type": "number" 
                 },
 				"memoryConfigured": { 
-                    "description": "kilobytes of memory configured in the virtual machine on which the VNFC reporting the event is running", 
+                    "description": "kibibytes of memory configured in the virtual machine on which the VNFC reporting the event is running", 
                     "type": "number" 
                 },
 				"memoryFree": { 
-                    "description": "kilobytes of physical RAM left unused by the system", 
+                    "description": "kibibytes of physical RAM left unused by the system", 
                     "type": "number" 
                 },
 				"memorySlabRecl": { 
-                    "description": "the part of the slab that can be reclaimed such as caches measured in kilobytes", 
+                    "description": "the part of the slab that can be reclaimed such as caches measured in kibibytes", 
                     "type": "number" 
                 },
 				"memorySlabUnrecl": { 
-                    "description": "the part of the slab that cannot be reclaimed even when lacking memory measured in kilobytes", 
+                    "description": "the part of the slab that cannot be reclaimed even when lacking memory measured in kibibytes", 
                     "type": "number" 
                 },
 				"memoryUsed": { 
-                    "description": "total memory minus the sum of free, buffered, cached and slab memory measured in kilobytes", 
+                    "description": "total memory minus the sum of free, buffered, cached and slab memory measured in kibibytes", 
                     "type": "number" 
                 },
 				"vmIdentifier": { 
@@ -1426,7 +1426,7 @@
                     "type": "number"
                 },
                 "summarySip": {
-                    "description": "the SIP Method or Response (‘INVITE’, ‘200 OK’, ‘BYE’, etc)",
+                    "description": "the SIP Method or Response (â€˜INVITEâ€™, â€˜200 OKâ€™, â€˜BYEâ€™, etc)",
                     "type": "string"
                 },
                 "vnfVendorNameFields": {
@@ -1499,7 +1499,7 @@
 			"type": "object",
 			"properties": {
 				"additionalFields": {
-					"description": "additional syslog fields if needed provided as name=value delimited by a pipe ‘|’ symbol, for example: 'name1=value1|name2=value2|…'",
+					"description": "additional syslog fields if needed provided as name=value delimited by a pipe â€˜|â€™ symbol, for example: 'name1=value1|name2=value2|â€¦'",
 					"type": "string"
 				},
 				"eventSourceHost": {


### PR DESCRIPTION
Showing Technology and Non-technology dependent domains
Corrected the Memory Measurement unit (should have been kibibytes and not Kilo Bytes)